### PR TITLE
fix: remove temp HOME isolation causing PATH mismatches (v0.3.1)

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -39,22 +39,26 @@ jobs:
         run: ${{ matrix.install_cmd }}
 
       - name: Smoke — smriti --version
+        shell: bash
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           smriti --version || bun "$HOME/.smriti/src/index.ts" --version
 
       - name: Smoke — smriti status
+        shell: bash
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           smriti status || bun "$HOME/.smriti/src/index.ts" status
 
       - name: Smoke — smriti ingest claude (no sessions OK)
+        shell: bash
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           smriti ingest claude || bun "$HOME/.smriti/src/index.ts" ingest claude
         continue-on-error: false
 
       - name: Smoke — smriti ingest copilot (no VS Code OK)
+        shell: bash
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           smriti ingest copilot || bun "$HOME/.smriti/src/index.ts" ingest copilot

--- a/install.ps1
+++ b/install.ps1
@@ -26,10 +26,7 @@ $ErrorActionPreference = "Stop"
 
 # ─── Config ──────────────────────────────────────────────────────────────────
 if ($CI) {
-  $HOME_DIR     = Join-Path ([System.IO.Path]::GetTempPath()) "smriti-ci-home"
-  $null         = New-Item -ItemType Directory -Force -Path $HOME_DIR
-  $env:USERPROFILE = $HOME_DIR
-  Write-Host "CI mode: using temp HOME $HOME_DIR"
+  Write-Host "CI mode: running in non-interactive mode"
 }
 
 $SMRITI_HOME  = Join-Path $env:USERPROFILE ".smriti"

--- a/install.sh
+++ b/install.sh
@@ -12,16 +12,15 @@
 set -euo pipefail
 
 # --- CI mode (used by GitHub Actions install-test.yml) -----------------------
-# Pass --ci to run non-interactively with a temp HOME directory.
+# Pass --ci to run non-interactively. Sets SMRITI_NO_HOOK to skip Claude Code hook.
 CI_MODE=0
 for arg in "$@"; do
   [ "$arg" = "--ci" ] && CI_MODE=1
 done
 
 if [ "$CI_MODE" = "1" ]; then
-  export HOME="$(mktemp -d /tmp/smriti-ci-XXXXX)"
   export SMRITI_NO_HOOK=1
-  echo "CI mode: using temp HOME $HOME"
+  echo "CI mode: skipping Claude Code hook setup"
 fi
 
 # --- Configuration -----------------------------------------------------------

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -11,10 +11,8 @@ param([switch]$CI)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-if ($CI) {
-  $HOME_DIR = Join-Path ([System.IO.Path]::GetTempPath()) "smriti-ci-home"
-  $env:USERPROFILE = $HOME_DIR
-}
+# Note: CI flag is accepted for compatibility but temp HOME is no longer used
+# (runner HOME is cleaned up automatically after job)
 
 $SMRITI_HOME  = Join-Path $env:USERPROFILE ".smriti"
 $BIN_DIR      = Join-Path $env:USERPROFILE ".local\bin"


### PR DESCRIPTION
## Problem

PR #25 merged partially - it included the QMD submodule fix but NOT the temp HOME removal. Install tests continue to fail because:

1. **CI mode uses temp HOME**: install scripts set `HOME=/tmp/smriti-ci-XXXXX` 
2. **Test steps use runner's HOME**: tests run with `HOME=/home/runner` (or `/Users/runner` on macOS)
3. **Path mismatch**: Files installed in temp HOME but tests look in runner's HOME
4. **Windows shell issue**: Workflow was missing `shell: bash`, so PowerShell was trying to run bash commands

## Solution

This PR contains the missing pieces:

### 1. Remove Temp HOME Isolation
- `install.sh`: Remove mktemp HOME assignment
- `install.ps1`: Remove USERPROFILE override  
- `uninstall.ps1`: Remove temp HOME logic

### 2. Add Explicit Bash Shell
- `install-test.yml`: Add `shell: bash` to all test steps
- Ensures bash is used on all platforms (critical for Windows with Git Bash)
- Makes `export PATH` commands work correctly

### 3. Keep Fallback Strategy  
- Tests use: `smriti || bun direct_execution`
- Works whether binary is in PATH or not

## Result

✅ Files install to runner's actual HOME (cleaned up after job)  
✅ Test steps use consistent bash environment  
✅ PATH exports work across all steps  
✅ Binary is found in correct HOME location  

🚀 Generated with [Claude Code](https://claude.com/claude-code)