### PR TITLE
fix: add --version command handler (v0.3.1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,13 @@ async function main() {
     return;
   }
 
+  // Handle --version early (doesn't need DB)
+  if (command === "--version" || command === "-v") {
+    const pkg = require("../package.json");
+    console.log(`smriti ${pkg.version}`);
+    return;
+  }
+
   // Initialize DB
   const db = initSmriti();
 


### PR DESCRIPTION
## Problem

The `smriti --version` command crashes with "Error: unable to open database file" because:

1. **No --version handler**: Command not implemented in switch statement
2. **DB init before command check**: `initSmriti()` is called before determining if the command needs DB
3. **CI environment**: Database file path doesn't exist in fresh CI runner

## Root Cause

```ts
async function main() {
  const command = args[0];
  
  // DB init happens BEFORE command handling
  const db = initSmriti();  // ← Tries to open/create DB here
  
  switch (command) {
    case "ingest": ...
    case "status": ...
    // No "version" case!
    default:
      console.error("Unknown command");
  }
}
```

When `--version` is passed:
1. `initSmriti()` is called → tries to open `~/.cache/qmd/index.sqlite`
2. DB initialization fails in CI (file system or permissions issue)
3. Error thrown before reaching command handler

## Solution

Handle `--version` **early**, like `--help`:

```ts
if (command === "--version" || command === "-v") {
  const pkg = require("../package.json");
  console.log(`smriti ${pkg.version}`);
  return;  // Exit before DB init
}
```

## Impact

✅ `smriti --version` works in any environment  
✅ No database required for --version command  
✅ Supports both `--version` and `-v` shorthand  
✅ Install tests can verify binary is working  

🚀 Generated with [Claude Code](https://claude.com/claude-code)