### PR TITLE
fix: add missing cline and copilot to default agents seed

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -408,6 +408,18 @@ const DEFAULT_AGENTS = [
     log_pattern: ".cursor/**/*.json",
     parser: "cursor",
   },
+  {
+    id: "cline",
+    display_name: "Cline",
+    log_pattern: "~/.cline/tasks/**/*.json",
+    parser: "cline",
+  },
+  {
+    id: "copilot",
+    display_name: "GitHub Copilot",
+    log_pattern: "*/chatSessions/*.json",
+    parser: "copilot",
+  },
 ] as const;
 
 /** Default category taxonomy */


### PR DESCRIPTION
## Summary

- `smriti_session_meta.agent_id` has a FOREIGN KEY referencing `smriti_agents(id)`, enforced by `PRAGMA foreign_keys = ON`
- Only `claude-code`, `codex`, and `cursor` were seeded in `DEFAULT_AGENTS`
- Ingesting copilot (or cline) sessions on a clean DB caused `FOREIGN KEY constraint failed` because those agent IDs didn't exist in `smriti_agents`
- Added `cline` and `copilot` entries to the seed data

Closes #30

## Test plan

- [x] `bun test test/ingest.test.ts test/db.test.ts` — 20 pass, 0 fail
- [x] Fresh DB: delete `~/.cache/qmd/index.sqlite`, run `smriti status`, then `smriti ingest copilot` — ingested without FK errors
- [x] Existing DB: `smriti ingest copilot` on a DB that already has data — idempotent, no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)