### PR TITLE
fix(test): tolerate EBUSY on Windows cursor-test cleanup

### DIFF
--- a/test/cursor-sqlite.test.ts
+++ b/test/cursor-sqlite.test.ts
@@ -167,7 +167,12 @@ beforeEach(() => {
 
 afterEach(() => {
   globalDb.close();
-  rmSync(tmpDir, { recursive: true, force: true });
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // Windows: SQLite file-lock release can lag close(), making rm throw
+    // EBUSY. The dir is under tmpdir() on an ephemeral runner — leak is fine.
+  }
 });
 
 test("discoverCursorSqliteSessions: fullConversationHeadersOnly with 2 bubbles", () => {


### PR DESCRIPTION
Fixes the last red workflow (CI Core, windows-latest only). All 14 cursor-sqlite tests failed on Windows because afterEach's `rmSync` races SQLite's file-lock release after `close()` and throws EBUSY. Wrap cleanup in try/catch — the dir is under tmpdir() on an ephemeral runner. ubuntu/macos were already green after #78.