### PR TITLE
fix(test): skip watchRecursive suite on win32

### DIFF
--- a/test/daemon-watcher.test.ts
+++ b/test/daemon-watcher.test.ts
@@ -29,7 +29,9 @@ const settle = (ms = 250) => new Promise((r) => setTimeout(r, ms));
 
 // Tests --------------------------------------------------------------
 
-describe("watchRecursive", () => {
+// The daemon is deferred on Windows (see release notes); Bun's fs.watch on
+// win32 hard-crashes the test process, so skip the suite there entirely.
+describe.skipIf(process.platform === "win32")("watchRecursive", () => {
   test("throws if root does not exist", () => {
     expect(() =>
       watchRecursive(join(tmpRoot, "does-not-exist"), () => {}),


### PR DESCRIPTION
Final red workflow fix. Windows job was dying mid-run inside `daemon-watcher.test.ts` (Bun's `fs.watch` hard-crash, no stack) — only 109 of 369 tests ever ran on win32, so the crash was also masking coverage for everything that *does* ship on Windows.

The daemon is explicitly deferred on Windows per the v0.8.0 release notes, so `describe.skipIf(win32)` on the watcher suite is the honest scope: unit-mocked daemon tests (server/queue/install/client) still run everywhere, and the other ~260 shipped-on-Windows tests now actually execute there.