### PR TITLE
fix(test): skip self-SIGTERM stopDaemon test on win32

### DIFF
--- a/test/daemon-client.test.ts
+++ b/test/daemon-client.test.ts
@@ -70,7 +70,11 @@ describe("stopDaemon", () => {
     expect(r.state).toBe("not-running");
   });
 
-  test("returns timeout when the daemon doesn't exit in the window", async () => {
+  // win32: there is no signal emulation — process.kill(pid, "SIGTERM") is
+  // TerminateProcess, so stopDaemon() SIGTERMing our own PID kills the test
+  // runner outright (no handler can swallow it). Daemon is unshipped on
+  // Windows; skip there.
+  test.skipIf(process.platform === "win32")("returns timeout when the daemon doesn't exit in the window", async () => {
     // Pin our own PID in the file. We won't actually receive SIGTERM in
     // this test process (the harness installs handlers), but the PID
     // file will keep saying we're alive, so stopDaemon will time out.


### PR DESCRIPTION
Root cause of the persistent windows-latest CI Core failure (survived #79 and #80): the `stopDaemon` timeout test pins **its own PID** in the daemon PID file, so `stopDaemon()` SIGTERMs the test runner. On Unix the test's no-op handler swallows it; on Windows `SIGTERM` = `TerminateProcess` — the runner dies instantly, mid-suite, with no failure output (exit 1, no summary, ~109/369 tests run). Both failing runs died deterministically when this file's turn came.

`test.skipIf(win32)` on that single test; the rest of daemon-client still runs everywhere. Consistent with the daemon being unshipped on Windows (v0.8.0 notes).