### PR TITLE
fix(test): skip real-socket startDaemon test on win32

### DIFF
--- a/test/daemon-server.test.ts
+++ b/test/daemon-server.test.ts
@@ -75,7 +75,9 @@ describe("startDaemon", () => {
   beforeEach(cleanupDaemonState);
   afterEach(cleanupDaemonState);
 
-  test("writes PID file and binds socket, shutdown() reverses both", async () => {
+  // win32: AF_UNIX socket binding behaves differently and the daemon is
+  // unshipped on Windows — skip the real-socket test there.
+  test.skipIf(process.platform === "win32")("writes PID file and binds socket, shutdown() reverses both", async () => {
     const logs: string[] = [];
     const handle = await startDaemon({ log: (m) => logs.push(m) });
 


### PR DESCRIPTION
Closes out the windows-latest CI Core failure chain (#78 → #79 → #80 → #81): after the self-SIGTERM fix, the full suite finally runs on Windows (369 tests, 360 pass) with exactly one failure — `startDaemon` binding a real AF_UNIX socket. Daemon is unshipped on Windows; skip the real-socket test there. Everything else in daemon-server (PID detection, stale-file recovery) still runs on all OSes.